### PR TITLE
Correct a desynchronization bug when converting songs in RetroTracker

### DIFF
--- a/tools/RetroTracker/src/KS_track.c
+++ b/tools/RetroTracker/src/KS_track.c
@@ -70,9 +70,6 @@ void KS_write_track(KS_FORMAT *ks,int *option,int out)
 		int end = 0;
 		int cmd = 0;
 
-		float fdelay = 0;
-		float oldfdelay = 0;
-
 		k = 0;
 		fticks = 0;
 
@@ -197,9 +194,9 @@ void KS_write_track(KS_FORMAT *ks,int *option,int out)
 
 			if(pattern != 0)
 			{
-				int tmp = fdelay;
+				int tmp = delay;
 				KS_delay_fputc(tmp,file);
-				oldfdelay = fticks;
+				olddelay = ticks;
 
 				int bnote = note;
 
@@ -224,12 +221,13 @@ void KS_write_track(KS_FORMAT *ks,int *option,int out)
 			}
 
 			fticks += fticks_line;
-			fdelay = (fticks-oldfdelay);
+			ticks = fticks;
+			delay = (ticks-olddelay);
 		}
 
-		int tmp = fdelay;
+		int tmp = delay;
 		KS_delay_fputc(tmp,file);
-		oldfdelay = fticks;
+		olddelay = ticks;
 		fputc(0,file);
 		fputc(0xFF,file);
 		fputc(0xFF,file);


### PR DESCRIPTION
Using a float for a delay value sounds good in theory, but in practice the SPC side doesn't support fractional delays in this manner, causing the fractional ticks to get lost instead of compensating for them. Since there's a tick counter already keeping track of things as a float, I replaced the float versions of the delay variables with their original integer counterparts and linked them up to an integer version of the tick counter, which simply grabbed the whole portion of the float tick counter.