### PR TITLE
Fix an orderlist size reading bug when converting patterns

### DIFF
--- a/tools/RetroTracker/src/it.c
+++ b/tools/RetroTracker/src/it.c
@@ -143,7 +143,7 @@ int IT_Load(char *name,int *option)
 	// convert pattern
 	size = 0;
 	i = 0;
-	for (i = 0; i < it.patnum; i++)
+	for (i = 0; i < it.ordnum-1; i++)
 	{
 		l = it.ord_table[i];
 		fseek(fichier,it.patOff[l],SEEK_SET);


### PR DESCRIPTION
When the number of orderlist entries does not equal the number of patterns in the IT file, an incorrect number of orderlist entries are read, resulting in blank data at the end of the file. This problem is now corrected.