### PR TITLE
Increase row size from 128 to standard IT maximum of 200

### DIFF
--- a/tools/RetroTracker/src/KS.h
+++ b/tools/RetroTracker/src/KS.h
@@ -53,7 +53,7 @@ typedef struct
 	KS_FORMAT_INSTRUMENTS *instruments;
 	KS_FORMAT_PATTERN **pattern;
 	//KS_FORMAT_PATTERN pattern[128][128];
-	int rows[128];
+	int rows[200];
 	int nrows,size_sample,size_track;
 
 }KS_FORMAT;


### PR DESCRIPTION
May be subject to revision down the road to account for OpenMPT-related shenanigans (or something else that supports more than 200 rows... or something that's not even in a pattern/row format).