### PR TITLE
Temporarily force the (relative) instrument volume setting to zero

### DIFF
--- a/tools/RetroTracker/src/KS_SNES.c
+++ b/tools/RetroTracker/src/KS_SNES.c
@@ -115,7 +115,8 @@ void KS_write_header_SNES(KS_FORMAT *ks,int *option,int out)
 			fputc(0x7F,file);
 			fputc(0xE0,file);
 			fputc(option[5],file);
-			fputc(instruments[i].volume,file);
+			fputc(0x00,file);
+			//fputc(instruments[i].volume,file);
 		}else
 		{
 			fputc(0x00,file);


### PR DESCRIPTION
The way the volume scaler is handled on the SPC side is not quite like a multiplicative scaler: instead, it implies a minimum note volume, and the note volume setting offsets off of this. This tends to throw off the way the volume is scaled on the SPC side, even causing wraparound situations under the wrong conditions. Thus, this has been de-facto commented out for the time being.