### PR TITLE
Track what channels are actually being used by the song

### DIFF
--- a/tools/RetroTracker/src/KS.h
+++ b/tools/RetroTracker/src/KS.h
@@ -46,7 +46,7 @@ typedef struct
 {
 	char id[4],name[28+32];
 
-	unsigned char Nchannels,Ninstruments,tempo,BPM;
+	unsigned char Nchannels,Ninstruments,tempo,BPM,chFlag;
 	int ticks,size_pattern;
 	int begin[32];
 

--- a/tools/RetroTracker/src/KS_PCE.c
+++ b/tools/RetroTracker/src/KS_PCE.c
@@ -31,13 +31,15 @@ void KS_write_header_PCE(KS_FORMAT *ks,int *option,int out)
 	printf("%d\n",ks->Ninstruments);
 
 	int Nchannels = 0;
-	for(i = 0;i <ks->Nchannels;i++)
-		Nchannels += 1<<i;
+	for(i = 0;i <ks->Nchannels;i++)	{
+		if ((ks->chFlag & (1<<i)) != 0)
+			Nchannels += 1;
+	}
 
-	printf("Nchannels : %d\n",ks->Nchannels);
+	printf("Nchannels : %d/%d\n",Nchannels,ks->Nchannels);
 
 	fputc(0x00,file); //flg
-    fputc(Nchannels,file); //kon
+    fputc(ks->chFlag,file); //kon
 
 	printf("ticks  : %d / 65535\n",ks->ticks);
 	printf("second : %d / 262\n",(ks->ticks*option[8])/8000);

--- a/tools/RetroTracker/src/KS_SNES.c
+++ b/tools/RetroTracker/src/KS_SNES.c
@@ -72,13 +72,15 @@ void KS_write_header_SNES(KS_FORMAT *ks,int *option,int out)
 
 
 	int Nchannels = 0;
-	for(i = 0;i <ks->Nchannels;i++)
-		Nchannels += 1<<i;
+	for(i = 0;i <ks->Nchannels;i++)	{
+		if ((ks->chFlag & (1<<i)) != 0)
+			Nchannels += 1;
+	}
 
-	printf("Nchannels : %d/8\n",ks->Nchannels);
+	printf("Nchannels : %d/%d\n",Nchannels,ks->Nchannels);
 
 	fputc(0x00,file); //flg
-    fputc(Nchannels,file); //kon
+    fputc(ks->chFlag,file); //kon
 
     for(i = 0;i < 11;i++) //efb,evoll,evollr ,firc0-c7
 		fputc(00,file);

--- a/tools/RetroTracker/src/KS_track.c
+++ b/tools/RetroTracker/src/KS_track.c
@@ -54,6 +54,7 @@ void KS_write_track(KS_FORMAT *ks,int *option,int out)
 	int i;
 	int testsize = 0;
 
+	ks->chFlag = 0;
 	for(i = 0;i < ks->Nchannels;i++)
 	{
 		int note = -1;
@@ -225,12 +226,15 @@ void KS_write_track(KS_FORMAT *ks,int *option,int out)
 			delay = (ticks-olddelay);
 		}
 
-		int tmp = delay;
-		KS_delay_fputc(tmp,file);
-		olddelay = ticks;
-		fputc(0,file);
-		fputc(0xFF,file);
-		fputc(0xFF,file);
+		if ((ftell(file)-ks->begin[i]-begin) != 0) {
+			ks->chFlag |= 1<<i;
+			int tmp = delay;
+			KS_delay_fputc(tmp,file);
+			olddelay = ticks;
+			fputc(0,file);
+			fputc(0xFF,file);
+			fputc(0xFF,file);
+		}
 	}
 
 


### PR DESCRIPTION
Sometimes there's no song data in the track that is converted. If that happens, then the channel bit is simply disabled so that the track doesn't waste a few bytes of memory in the process. The local Nchannels report was also modified to count the number of channels allocated for the song (6 or 8 depending on command line options) versus the number of channels actually used.