### PR TITLE
Optimize handling note cuts in conversions

### DIFF
--- a/tools/RetroTracker/src/KS_track.c
+++ b/tools/RetroTracker/src/KS_track.c
@@ -57,6 +57,7 @@ void KS_write_track(KS_FORMAT *ks,int *option,int out)
 	for(i = 0;i < ks->Nchannels;i++)
 	{
 		int note = -1;
+		int prevnote = -1;
 		int index = -1;
 		int volume = -1;
 		int delay = 0;
@@ -165,12 +166,14 @@ void KS_write_track(KS_FORMAT *ks,int *option,int out)
 			//note
 			if(flags&0x01)
 			{
-				if(note != ks->pattern[i][l].note)
+				if(prevnote != ks->pattern[i][l].note)
 					pattern |= 0x1;
 				else
 					pattern |= 0x2;
 
 				note = ks->pattern[i][l].note;
+				if (note != 0)
+					prevnote = note;
 			}
 
 			//instrument

--- a/tools/RetroTracker/src/KS_track.c
+++ b/tools/RetroTracker/src/KS_track.c
@@ -58,6 +58,7 @@ void KS_write_track(KS_FORMAT *ks,int *option,int out)
 	{
 		int note = -1;
 		int prevnote = -1;
+		int prevnoteNOKOFF = -1;
 		int index = -1;
 		int volume = -1;
 		int delay = 0;
@@ -166,14 +167,17 @@ void KS_write_track(KS_FORMAT *ks,int *option,int out)
 			//note
 			if(flags&0x01)
 			{
-				if(prevnote != ks->pattern[i][l].note)
+				if(prevnoteNOKOFF != ks->pattern[i][l].note)
 					pattern |= 0x1;
 				else
 					pattern |= 0x2;
 
 				note = ks->pattern[i][l].note;
 				if (note != 0)
-					prevnote = note;
+					prevnoteNOKOFF = note;
+				else if (prevnote == 0)
+					pattern &= 0xFC;
+				prevnote = note;
 			}
 
 			//instrument


### PR DESCRIPTION
Two modifications were made to the conversion code: one of them saves the note after a note cut is issued because the note itself is still saved on the SPC side. The other one merges multiple note cut commands in a row into one, merging all of the delays in the process. These together reduce the output filesize of the converted song.