### PR TITLE
Adjust default volume handling on conversion

### DIFF
--- a/tools/RetroTracker/src/KS_track.c
+++ b/tools/RetroTracker/src/KS_track.c
@@ -84,8 +84,6 @@ void KS_write_track(KS_FORMAT *ks,int *option,int out)
 		int ibuf = 0;
 		int oldibuf = 0;
 
-		int first_v = 0;
-
 		k = 0;
 		fticks = 0;
 
@@ -234,18 +232,15 @@ void KS_write_track(KS_FORMAT *ks,int *option,int out)
 				oldibuf = ibuf;
 
 
-				if (first_v == 0)
+				if (!(flags&0x04))
 				{
-					if(pattern&0x04)
+					if(!(pattern&0x04))
 					{
-
-					}else
-					{
+						if (volume != ks->instruments[index].volume)
+							pattern |= 0x04;
 						volume = ks->instruments[index].volume;
-						pattern |= 0x04;
 					}
 				}
-				first_v = 1;
 
 
 				if(bnote != 0)


### PR DESCRIPTION
Generally speaking, the default volume is fetched if volume is not defined when preparing to set up a note.